### PR TITLE
Commits out Maints Mushroom spawning 

### DIFF
--- a/code/game/objects/effects/spawners/maintshroom.dm
+++ b/code/game/objects/effects/spawners/maintshroom.dm
@@ -1,3 +1,4 @@
+/*
 /obj/effect/spawner/maintshroom
 	name = "maintshroom spawner"
 	icon = 'icons/mob/screen1.dmi'
@@ -55,3 +56,4 @@
 	new /obj/effect/plant(get_turf(B), new /datum/seed/mushroom/maintshroom)
 
 	qdel(src)
+*/

--- a/code/game/objects/random/flora.dm
+++ b/code/game/objects/random/flora.dm
@@ -3,11 +3,11 @@
 	icon_state = "nature-purple"
 	alpha = 128
 
-//More will be added later, for now just shrooms
-/obj/random/flora/item_to_spawn()
-	return /obj/effect/spawner/maintshroom/delayed
+//More will be added later, for now just shrooms - When this is fixed that is -_- 
+///obj/random/flora/item_to_spawn()
+//	return /obj/effect/spawner/maintshroom/delayed
 
 /obj/random/flora/low_chance
 	name = "low chance random flora"
 	icon_state = "nature-purple-low"
-	spawn_nothing_percentage = 83
+	spawn_nothing_percentage = 100


### PR DESCRIPTION
It grows way to fast, no one deals with them. They kill off all the mobs in maints, and over run everything way to fast to be dealable with any time within a year

They also spawn without end in random areas over and over for no real reason.