### PR TITLE
Hotfixes loadout cloak path

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -53,7 +53,7 @@
 	path = /obj/item/clothing/suit/storage/miljacket
 	flags = GEAR_HAS_TYPE_SELECTION
 
-/datum/gear/suit/cloak
+/datum/gear/suit/cloak/simple
 	display_name = "cloak selection"
 	path = /obj/item/clothing/suit/hooded/cloak/simple
 	flags = GEAR_HAS_TYPE_SELECTION


### PR DESCRIPTION
Changes cloak path, so jobwise cloaks wont get gear selection for no reason.

I'm complete buffoon.