### PR TITLE
Changes admin permissions, Re-enables ghost ship story mode

### DIFF
--- a/code/__defines/admin.dm
+++ b/code/__defines/admin.dm
@@ -28,6 +28,7 @@
 #define R_PERMISSIONS   0x8
 #define R_MENTOR        0x10
 #define R_MOD           0x20
+#define R_SOUND         0x30
 #define R_ADMIN         0x40
 
 // Host permission (sum of all permissions above) is equal to 127 or 0x7F

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -77,12 +77,14 @@ var/list/admin_ranks = list() //list of all ranks with associated rights
 					rights |= R_FUN
 				if("server")
 					rights |= R_SERVER
+				if("sound")
+					rights |= R_SOUND
 				if("debug")
 					rights |= R_DEBUG
 				if("permissions", "rights")
 					rights |= R_PERMISSIONS
 				if("everything", "host", "all")
-					rights |= (R_ADMIN | R_FUN | R_SERVER | R_DEBUG | R_PERMISSIONS | R_MOD | R_MENTOR)
+					rights |= (R_ADMIN | R_FUN | R_SERVER | R_DEBUG | R_PERMISSIONS | R_MOD | R_MENTOR | R_SOUND)
 				if("mod")
 					rights |= R_MOD
 				if("mentor")
@@ -146,7 +148,7 @@ var/list/admin_ranks = list() //list of all ranks with associated rights
 	if(!dbcon.IsConnected())
 		return flag
 
-	var/DBQuery/query = dbcon.NewQuery("SELECT fun, server, debug, permissions, mentor, moderator, admin, host FROM permissions WHERE player_id = [player_id]")
+	var/DBQuery/query = dbcon.NewQuery("SELECT fun, server, debug, permissions, mentor, moderator, sound, admin, host FROM permissions WHERE player_id = [player_id]")
 	if(!query.Execute())
 		return flag
 
@@ -159,8 +161,9 @@ var/list/admin_ranks = list() //list of all ranks with associated rights
 			"permissions" = query.item[4],
 			"mentor" = query.item[5],
 			"moderator" = query.item[6],
-			"admin" = query.item[7],
-			"host" = query.item[8],
+			"sound" = query.item[7],
+			"admin" = query.item[8],
+			"host" = query.item[9],
 		)
 
 	for(var/key in permissions)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -128,7 +128,7 @@ ADMIN_VERB_ADD(/client/proc/player_panel_new, R_ADMIN, TRUE)
 		holder.player_panel_new()
 
 
-ADMIN_VERB_ADD(/client/proc/storyteller_panel, R_ADMIN|R_MOD, TRUE)
+ADMIN_VERB_ADD(/client/proc/storyteller_panel, R_ADMIN|R_MOD|R_FUN, TRUE)
 /client/proc/storyteller_panel()
 	set name = "Storyteller Panel"
 	set category = "Admin"
@@ -466,7 +466,7 @@ ADMIN_VERB_ADD(/client/proc/change_human_appearance_self, R_ADMIN, FALSE)
 			H.change_appearance(APPEARANCE_ALL, H.loc, check_species_whitelist = 1)
 
 
-ADMIN_VERB_ADD(/client/proc/change_security_level, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/change_security_level, R_ADMIN|R_FUN, FALSE)
 /client/proc/change_security_level()
 	set name = "Set security level"
 	set desc = "Sets the station security level"

--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB_ADD(/client/proc/cmd_admin_change_custom_event, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/cmd_admin_change_custom_event, R_ADMIN|R_FUN, FALSE)
 // verb for admins to set custom event
 /client/proc/cmd_admin_change_custom_event()
 	set category = "Fun"

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -5,7 +5,7 @@
 
 	var/method = 0	//0 means strict type detection while 1 means this type and all subtypes (IE: /obj/item with this set to 1 will set it to ALL itms)
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_DEBUG))
 		return
 
 	if(A && A.type)
@@ -25,7 +25,7 @@
 
 
 /client/proc/massmodify_variables(var/atom/O, var/var_name = "", var/method = 0)
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_DEBUG))
 		return
 
 	var/list/locked = list("vars", "key", "ckey", "client")

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -1,8 +1,8 @@
 var/list/sounds_cache = list()
 
-ADMIN_VERB_ADD(/client/proc/play_sound, R_FUN, FALSE)
+ADMIN_VERB_ADD(/client/proc/play_sound, R_SOUND, FALSE)
 /client/proc/play_sound(S as sound)
-	set category = "Fun"
+	set category = "Sound"
 	set name = "Play Global Sound"
 	if(!check_rights(R_FUN))
 		return
@@ -23,9 +23,9 @@ ADMIN_VERB_ADD(/client/proc/play_sound, R_FUN, FALSE)
 
 
 
-ADMIN_VERB_ADD(/client/proc/play_local_sound, R_FUN, FALSE)
+ADMIN_VERB_ADD(/client/proc/play_local_sound, R_SOUND, FALSE)
 /client/proc/play_local_sound(S as sound)
-	set category = "Fun"
+	set category = "Sound"
 	set name = "Play Local Sound"
 	if(!check_rights(R_FUN))
 		return
@@ -35,9 +35,9 @@ ADMIN_VERB_ADD(/client/proc/play_local_sound, R_FUN, FALSE)
 	playsound(get_turf(src.mob), S, 50, 0, 0)
 
 
-ADMIN_VERB_ADD(/client/proc/play_server_sound, R_FUN, FALSE)
+ADMIN_VERB_ADD(/client/proc/play_server_sound, R_SOUND, FALSE)
 /client/proc/play_server_sound()
-	set category = "Fun"
+	set category = "Sound"
 	set name = "Play Server Sound"
 	if(!check_rights(R_FUN))
 		return
@@ -55,7 +55,7 @@ ADMIN_VERB_ADD(/client/proc/play_server_sound, R_FUN, FALSE)
 
 ADMIN_VERB_ADD(/client/proc/stop_sounds, R_ADMIN, FALSE)
 /client/proc/stop_sounds()
-	set category = "Debug"
+	set category = "Sound"
 	set name = "Stop All Playing Sounds"
 	if(!src.holder)
 		return
@@ -65,9 +65,9 @@ ADMIN_VERB_ADD(/client/proc/stop_sounds, R_ADMIN, FALSE)
 		if(M.client)
 			sound_to(M, sound(null, repeat = 0, wait = 0, volume = 100))
 
-ADMIN_VERB_ADD(/client/proc/stop_sounds_admin, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/stop_sounds_admin, R_SOUND, FALSE)
 /client/proc/stop_sounds_admin() //Selectively shuts up bad admin played songs only without destroying every sound in the game.
-	set category = "Debug"
+	set category = "Sound"
 	set name = "Stop Admin Sounds"
 	if(!src.holder)
 		return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -15,7 +15,7 @@
 	log_admin("[key_name(usr)] made [key_name(M)] drop everything!")
 	message_admins("[key_name_admin(usr)] made [key_name_admin(M)] drop everything!", 1)
 
-ADMIN_VERB_ADD(/client/proc/cmd_admin_subtle_message, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/cmd_admin_subtle_message, R_FUN, FALSE)
 //send an message to somebody as a 'voice in their head'
 /client/proc/cmd_admin_subtle_message(mob/M as mob in SSmobs.mob_list)
 	set category = "Special Verbs"
@@ -39,7 +39,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_subtle_message, R_ADMIN, FALSE)
 	message_admins("\blue \bold SubtleMessage: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]", 1)
 
 
-ADMIN_VERB_ADD(/client/proc/cmd_admin_world_narrate, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/cmd_admin_world_narrate, R_FUN, FALSE)
 //sends text to all players with no padding
 /client/proc/cmd_admin_world_narrate() // Allows administrators to fluff events a little easier -- TLE
 	set category = "Special Verbs"
@@ -308,7 +308,7 @@ If a guy was gibbed and you want to revive him, this is a good way to do so.
 Works kind of like entering the game with a new character. Character receives a new mind if they didn't have one.
 Traitors and the like can also be revived with the previous role mostly intact.
 /N */
-ADMIN_VERB_ADD(/client/proc/respawn_character, R_FUN, FALSE)
+ADMIN_VERB_ADD(/client/proc/respawn_character, R_ADMIN, FALSE)
 /client/proc/respawn_character()
 	set category = "Special Verbs"
 	set name = "Respawn Character"
@@ -445,7 +445,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_add_freeform_ai_law, R_FUN, FALSE)
 		command_announcement.Announce("Ion storm detected near the ship. Please check all AI-controlled equipment for errors.", "Anomaly Alert", new_sound = 'sound/AI/ionstorm.ogg')
 
 
-ADMIN_VERB_ADD(/client/proc/cmd_admin_rejuvenate, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/cmd_admin_rejuvenate, R_ADMIN|R_MOD, FALSE)
 /client/proc/cmd_admin_rejuvenate(mob/living/M as mob in SSmobs.mob_list)
 	set category = "Special Verbs"
 	set name = "Rejuvenate"
@@ -466,7 +466,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_rejuvenate, R_ADMIN, FALSE)
 		alert("Admin revive disabled")
 
 
-ADMIN_VERB_ADD(/client/proc/cmd_admin_create_centcom_report, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/cmd_admin_create_centcom_report, R_FUN, FALSE)
 /client/proc/cmd_admin_create_centcom_report()
 	set category = "Special Verbs"
 	set name = "Create Command Report"
@@ -510,7 +510,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_delete, R_ADMIN|R_SERVER|R_DEBUG, FALSE)
 
 		qdel(O)
 
-ADMIN_VERB_ADD(/client/proc/cmd_admin_list_open_jobs, R_DEBUG, FALSE)
+ADMIN_VERB_ADD(/client/proc/cmd_admin_list_open_jobs, R_ADMIN|R_DEBUG, FALSE)
 /client/proc/cmd_admin_list_open_jobs()
 	set category = "Admin"
 	set name = "List free slots"
@@ -730,7 +730,7 @@ ADMIN_VERB_ADD(/client/proc/toggle_view_range, R_ADMIN, FALSE)
 
 
 
-ADMIN_VERB_ADD(/client/proc/admin_call_shuttle, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/admin_call_shuttle, R_ADMIN|R_FUN, FALSE)
 //allows us to call the emergency shuttle
 /client/proc/admin_call_shuttle()
 
@@ -740,7 +740,7 @@ ADMIN_VERB_ADD(/client/proc/admin_call_shuttle, R_ADMIN, FALSE)
 	if(!evacuation_controller)
 		return
 
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN|R_FUN))	return
 
 	if(alert(src, "Are you sure?", "Confirm", "Yes", "No") != "Yes") return
 
@@ -752,13 +752,13 @@ ADMIN_VERB_ADD(/client/proc/admin_call_shuttle, R_ADMIN, FALSE)
 	message_admins("\blue [key_name_admin(usr)] admin-called the emergency shuttle.", 1)
 	return
 
-ADMIN_VERB_ADD(/client/proc/admin_cancel_shuttle, R_ADMIN, FALSE)
+ADMIN_VERB_ADD(/client/proc/admin_cancel_shuttle, R_ADMIN|R_FUN, FALSE)
 //allows us to cancel the emergency shuttle, sending it back to centcomm
 /client/proc/admin_cancel_shuttle()
 	set category = "Admin"
 	set name = "Cancel Evacuation"
 
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN|R_FUN))	return
 
 	if(alert(src, "You sure?", "Confirm", "Yes", "No") != "Yes") return
 
@@ -779,7 +779,7 @@ ADMIN_VERB_ADD(/client/proc/admin_cancel_shuttle, R_ADMIN, FALSE)
 	if (!evacuation_controller)
 		return
 
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN|R_FUN))	return
 
 	evacuation_controller.deny = !evacuation_controller.deny
 

--- a/config/example/admin_ranks.txt
+++ b/config/example/admin_ranks.txt
@@ -27,8 +27,8 @@ Mentor          +MENTOR
 
 Admin Candidate	+ADMIN
 Trial Admin		+@ +BAN
-Badmin			+@ +SERVER +FUN
-Game Admin		+@ +DEBUG +PERMISSIONS + SOUND
+Badmin			+@ +SERVER +FUN +SOUND
+Game Admin		+@ +DEBUG +PERMISSIONS
 Game Master		+EVERYTHING
 Head Admin		+EVERYTHING
 Retired Admin	+ADMIN

--- a/config/example/admin_ranks.txt
+++ b/config/example/admin_ranks.txt
@@ -18,6 +18,7 @@
 # +SERVER = higher-risk admin verbs and abilities, such as those which affect the server configuration.
 # +DEBUG = debug tools used for diagnosing and fixing problems. It's useful to give this to coders so they can investigate problems on a live server.
 # +RIGHTS (or +PERMISSIONS) = allows you to promote and/or demote people.
+# +SOUND = allows you to play sounds/stop all server sounds
 # +EVERYTHING (or +HOST or +ALL) = Simply gives you everything without having to type every flag
 
 Admin Observer
@@ -27,7 +28,7 @@ Mentor          +MENTOR
 Admin Candidate	+ADMIN
 Trial Admin		+@ +BAN
 Badmin			+@ +SERVER +FUN
-Game Admin		+@ +DEBUG +PERMISSIONS
+Game Admin		+@ +DEBUG +PERMISSIONS + SOUND
 Game Master		+EVERYTHING
 Head Admin		+EVERYTHING
 Retired Admin	+ADMIN

--- a/odessa-outpost.dme
+++ b/odessa-outpost.dme
@@ -554,6 +554,7 @@
 #include "code\game\gamemodes\roleset\faction\mercenary.dm"
 #include "code\game\gamemodes\roleset\faction\roleset_faction.dm"
 #include "code\game\gamemodes\storytellers\chronicler.dm"
+#include "code\game\gamemodes\storytellers\ghostship.dm"
 #include "code\game\gamemodes\storytellers\guide.dm"
 #include "code\game\gamemodes\storytellers\healer.dm"
 #include "code\game\gamemodes\storytellers\jester.dm"


### PR DESCRIPTION
Changes some of the admin perms, to more appropiate permission area, like mass edit being +debug(lets be honest don't trust a normal admin with mass edit 👅
Gives anything sound related its own tab so you can quick to it and stop sounds without finding a silly button 😠 

And also re-enables the "ghost ship" storyteller which is zero events, also require zero crew to start up.