### PR TITLE
Simple animals no longer repeatedly call death() every life tick when dead.

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -147,7 +147,7 @@
 
 /mob/living/simple_animal/updatehealth()
 	..()
-	if (health <= 0)
+	if (health <= 0 && stat != DEAD)
 		death()
 
 /mob/living/simple_animal/examine(mob/user)


### PR DESCRIPTION
Fixes alien death screeches repeatedly playing, and any other undiscovered issues that may have occurred due to this.

Could be worth untangling simple mob code as a whole down the lines to streamline a lot of this. For example, the death check in `mob/living/simple_animal/updatehealth()` will always proc before the death check in `mob/living/simple_animal/Life()` as its parent, `/mob/living/Life()`, calls `updatehealth()` through `handle_regular_status_updates()`