### PR TITLE
Handcuffs now set their equip_slot.

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -29,6 +29,7 @@
 		return
 
 	if(C.handcuffed)
+		to_chat(user,SPAN_WARNING("\The [C] is already handcuffed."))
 		return
 
 	if (C == user) //cool shit bro
@@ -46,6 +47,9 @@
 				cuff_delay /= 2 //0.75
 			if(G.state >= GRAB_KILL)
 				cuff_delay = 0
+	if(C.handcuffed)
+		to_chat(user,SPAN_WARNING("\The [C] is already handcuffed."))
+		return
 	place_handcuffs(C, user, cuff_delay)
 
 /obj/item/weapon/handcuffs/proc/place_handcuffs(var/mob/living/carbon/target, var/mob/user, var/delay)
@@ -84,7 +88,8 @@
 		cuffs = new(get_turf(user))
 	else
 		user.drop_from_inventory(cuffs)
-	cuffs.loc = target
+	cuffs.forceMove(target)
+	cuffs.equip_slot = slot_handcuffed
 	target.handcuffed = cuffs
 	target.update_inv_handcuffed()
 	return 1

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -89,7 +89,6 @@
 	else
 		user.drop_from_inventory(cuffs)
 	cuffs.forceMove(target)
-	cuffs.equip_slot = slot_handcuffed
 	target.handcuffed = cuffs
 	target.update_inv_handcuffed()
 	return 1

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -991,6 +991,7 @@ mob/living/carbon/human/proc/get_wings_image()
 		drop_r_hand()
 		drop_l_hand()
 		stop_pulling()	//TODO: should be handled elsewhere
+		handcuffed.equip_slot = slot_handcuffed
 
 		var/image/standing
 		if(handcuffed.icon_override)


### PR DESCRIPTION
Fixes #66 
Also added in a second check for if(C.handcuffed) after the do_after(), to prevent weirdness with multiple players attempting to cuff the same target, and messages for clicking on a target who is already cuffed.