### PR TITLE
Fixing 'empty contents' verb 2: Electric Boogaloo.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -477,16 +477,16 @@
 			if(collectItems(get_turf(A), user))
 				return TRUE
 	//Clicking on tile with no collectible items will empty it, if it has the verb to do that.
-	if(src.verbs.Find(/obj/item/weapon/storage/verb/quick_empty))
-		if(isturf(A))
-			src.quick_empty(A)
+	if(allow_quick_empty)
+		if(isturf(A) && !A.density)
+			dump_it(A)
 			return TRUE
-
 	return ..()
 
 /obj/item/weapon/storage/verb/quick_empty()
 	set name = "Empty Contents"
 	set category = "Object"
+	set src in view(1)
 
 	if((!ishuman(usr) && (src.loc != usr)) || usr.stat || usr.restrained())
 		return
@@ -494,9 +494,15 @@
 	var/turf/T = get_turf(src)
 	if(!istype(T))
 		return
+	dump_it(T)
+
+
+/obj/item/weapon/storage/proc/dump_it(var/turf/target) //he bought?
+	if(!isturf(target))
+		return
 	hide_from(usr)
 	for(var/obj/item/I in contents)
-		remove_from_storage(I, T)
+		remove_from_storage(I, target)
 
 /obj/item/weapon/storage/New()
 	..()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -311,25 +311,26 @@
 
 /obj/item/ammo_magazine/resolve_attackby(atom/A, mob/user)
 	//Clicking on tile with no collectible items will empty it, if it has the verb to do that.
-	if(isturf(A))
-		src.quick_empty(A)
+	if(isturf(A) && !A.density)
+		dump_it(A)
 		return TRUE
 	return ..()
 
-/obj/item/ammo_magazine/verb/quick_empty(var/turf/target)
+/obj/item/ammo_magazine/verb/quick_empty()
 	set name = "Empty Ammo Container"
 	set category = "Object"
+	set src in view(1)
 
 	if((!ishuman(usr) && (src.loc != usr)) || usr.stat || usr.restrained())
 		return
 
-	var/turf/T
-	if(isturf(target))
-		T = target
-	else
-		T = get_turf(src)
-
+	var/turf/T = get_turf(src)
 	if(!istype(T))
+		return
+	dump_it(T)
+
+/obj/item/ammo_magazine/proc/dump_it(var/turf/target)
+	if(!istype(target))
 		return
 
 	if(!stored_ammo.len)
@@ -338,7 +339,7 @@
 	to_chat(usr, SPAN_NOTICE("You take out ammo from [src]."))
 	for(var/i=1 to stored_ammo.len)
 		var/obj/item/ammo_casing/C = removeCasing()
-		C.forceMove(T)
+		C.forceMove(target)
 		C.set_dir(pick(cardinal))
 	update_icon()
 


### PR DESCRIPTION
quick_empty() and resolve_attackby() now call dump_it() to do the actual work so that i don't have to wrangle a verb into doing two different things.
can now access quick_empty() from a tile away, in case you want to put a bag on a table and spill its contents.
resolve_attackby() now checks if the tile you want to dump on is dense, preventing through-wall trading of items.
magazines have also been updated with the same fixes and adjustments.

merge at leisure because it's functional and unexploitable as-is; this just restores dumping contents onto a turf by clicking on it, and fixes some related bugs.