### PR TITLE
Makes tablets hold wieght class two items

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
@@ -7,7 +7,7 @@
 
 	icon_state_menu = "menu"
 	hardware_flag = PROGRAM_TABLET
-	max_hardware_size = 1
+	max_hardware_size = 2 //Sos change
 	w_class = ITEM_SIZE_SMALL
 	screen_light_strength = 2.1
 	screen_light_range = 2.1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tablets have been now fitted to fit bigger wieght classes like better NTN Relay and or a 258MB harddrive

## Why It's Good For The Game

Tablets are bigger and dont even fit on labcoat suits, this should make them more worth to get then a round start free PDA

## Changelog
:cl:
add: Thanks to the work of Moebius tablets now are able to fit in slightly more items into its modular ports
/:cl:
