### PR TITLE
Underwear color fix

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -333,7 +333,7 @@ var/global/list/wings_icon_cache = list()
 			var/obj/item/underwear/UW = entry
 			var/icon/I = new /icon(form.underwear_icon, UW.icon_state)
 			if(UW.color)
-				I.Blend(UW.color, ICON_ADD)
+				I.Blend(UW.color, ICON_MULTIPLY)
 			underwear.Blend(I, ICON_OVERLAY)
 		overlays_standing[UNDERWEAR_LAYER] = image(underwear)
 	if(update_icons)


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
one-line change that makes underwear color correctly
</summary>
<hr>

I'm not really sure how this wasn't figured out sooner. The only issue underwear colors had was that line 336 of carbon/human/update_icons.dm was using ICON_ADD instead of ICON_MULTIPLY.
Since ICON_ADD tries to add the two colors together it can't get a color above #ffffff and therefore doesn't work with primarily white icons, which the underwear icons are.
ICON_MULTIPLY multiplies the two colors as if they were numbers between 0 and 1, meaning that it works with white icons but not black ones.

In the future, it might be worth using a var on each underwear piece to determine whether it gets added or multiplied, but this likely wouldn't see much use - maybe just with the striped underwear so that you can have variants for black/color stripes and white/color stripes.
	
<hr>
</details>

## Changelog
:cl:
fix: Underwear icons now use ICON_MULTIPLY rather than ICON_ADD
/:cl:
